### PR TITLE
RNA working silution plates use different purpose

### DIFF
--- a/config/bridge.yml
+++ b/config/bridge.yml
@@ -7,8 +7,8 @@ plate_management: &plate_management_settings
   roles_purpose_ids:
     "samples.rack.stock.dna": 2
     "samples.rack.stock.rna": 183
-    "samples.qc.nx_nanodrop.working_dilution_rna": 1
-    "samples.qc.nx_nanodrop.working_dilution_rna.nanodrop": 1
+    "samples.qc.nx_nanodrop.working_dilution_rna": 206
+    "samples.qc.nx_nanodrop.working_dilution_rna.nanodrop": 206
     "samples.qc.nx_nanodrop.volume_checked_stock_rack_rna.batched": 183
     "samples.qc.nx_nanodrop.volume_checked_stock_rack_rna": 183
     "samples.qc_gel.imager.rna": 14
@@ -36,7 +36,7 @@ plate_management: &plate_management_settings
     "ND": "Plate"
     "NR": "Plate"
     "WD": "Working dilution"
-    "WR": "Working dilution"
+    "WR": "RNA Working dilution"
     "GR": "Gel Dilution Plate"
   gel_image_s2_scores_to_sequencescape_scores:
     "pass": "OK"


### PR DESCRIPTION
Fluidigm submissions in Sequencescape are made from working dilution
plates. These are selected using a purpose and a sample name. However
if a sample has come across the bridge, but DNA and RNA samples are
on Working Dilution plates, and Sequencescape can't distinguish between
them. (Except by barcode prefix, but using that would break pattern)

I've added a new purpose to Sequencescape for RNA Working Diltion.
I believe these changes are all thats needed to ensure the bridge uses it,
but as I'm not familiar with the inner workings of S2 or the bridge,
I may have missed something important.
